### PR TITLE
Nominating Justin Downie for the open chair position

### DIFF
--- a/ART_MEMBERS.md
+++ b/ART_MEMBERS.md
@@ -9,6 +9,7 @@ By adding your name to this file you confirm that you understand and agree to th
 * [Dustin Black](https://github.com/dustinblack)
 * [Sandro Bonazzola](https://github.com/sandrobonazzola)
 * [Jared O'Connell](https://github.com/jaredoconnell)
+* [Justin Downie](https://github.com/jdowni000) 
 
 
 ## ART Members
@@ -16,7 +17,6 @@ By adding your name to this file you confirm that you understand and agree to th
 *Add your name and GitHub profile link below this line via a pull request to this repository.*
 * [Matthew F Leader](https://github.com/mfleader)
 * [Harshith Umesh](https://github.com/Harshith-umesh)
-* [Justin Downie](https://github.com/jdowni000)
 * [Michael Engel](https://github.com/engelmi)
 * [Hubert Stefanski](https://github.com/HubertStefanski)
 * [Ryan Smith](https://github.com/AvlWx2014)

--- a/art-decisions/proposals/2023-05-16-downie-chair-nomination.md
+++ b/art-decisions/proposals/2023-05-16-downie-chair-nomination.md
@@ -1,0 +1,15 @@
+# Chair Nomination: [Justin Downie](https://github.com/jdowni000)
+
+I hereby nominate [Justin Downie](https://github.com/jdowni000) as a Chair of Arcalot.
+
+## Reasons
+
+Justin…
+* is a very active and responsive member of the ART
+* has shown leadership in developing core aspects of our critical automation systems
+* has experience with open source organizations and the CNCF
+* openly accepts and provides valuable criticism in the name of bettering the project
+
+## Voting Period
+
+The voting period starts on the 16th of May 2023 and ends on the 23th of May 2023. All current ART members are eligible to vote and are considered for quorum approval.


### PR DESCRIPTION
## Changes introduced with this PR

I hereby nominate Justin Downie for the open chair position.

The voting period starts on the 16th of May 2023 and ends on the 23th of May 2023. All current ART members are eligible to vote and are considered for quorum approval.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).